### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+This repo is open to contributions from **everyone**.
+
+By participating in this project, you agree to abide by the [XMTP code of conduct](https://xmtp.org/community/code-of-conduct).
+
+## Pull requests
+
+XMTP welcomes pull requests from everyone. 
+
+Before diving in, consider posting to [XMTP Discord](https://discord.gg/xmtp) or [XMTP GitHub Discussions](https://github.com/orgs/xmtp/discussions) to get a quick temperature check on your idea.
+
+## Bugs
+
+Report a bug using the **Issues** tab in this repo.
+
+## Feature requests
+
+Open a feature request using the **Issues** tab in this repo to suggest an idea or enhancement.
+
+## Questions
+
+Have questions? Learn with the community by posting to [XMTP Discord](https://discord.gg/xmtp) or [XMTP GitHub Discussions](https://github.com/orgs/xmtp/discussions).
+
+## Follow XMTP
+
+To keep up with the latest XMTP news and releases, follow [@XMTP_](https://twitter.com/xmtp_) on Twitter.


### PR DESCRIPTION
Adds a generic CONTRIBUTING.md that can display for XMTP Labs org repos that don't have explicit contribution guidelines defined.

Providing this file as a clear sign to people that all XMTP Labs public repos are open to contributions from everyone, after hearing feedback that this was not clear about one of the public repos.

Ideally, each repo should have contribution guidelines specific to the repo (language, formatting, tests, etc), but this generic file can serve a purpose in the meantime.